### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -40,7 +40,7 @@ compile 'com.haozhang.libary:android-slanted-textview:1.2'
 ![注意](https://github.com/HeZaiJin/SlantedTextView/blob/master/screen_shot/note.png)
 ## SlantedMode
 ![SlantedMode](https://github.com/HeZaiJin/SlantedTextView/blob/master/screen_shot/slanted_mode.png)
-#License
+# License
 ```
 Copyright 2016 Hand HaoZhang
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ compile 'com.haozhang.libary:android-slanted-textview:1.2'
 ![注意](https://github.com/HeZaiJin/SlantedTextView/blob/master/screen_shot/note.png)
 ## SlantedMode
 ![SlantedMode](https://github.com/HeZaiJin/SlantedTextView/blob/master/screen_shot/slanted_mode.png)
-#License
+# License
 ```
 Copyright 2016 Hand HaoZhang
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
